### PR TITLE
Add default renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,9 @@
+{
+  "extends": [
+    "config:base"
+  ],
+  "schedule": [
+    "before 5am on Monday"
+  ],
+  "automerge": false
+}


### PR DESCRIPTION
A minimal `renovate.json` file was added automatically so that the repository can be processed by the `python_demonstrator` workflow. Feel free to adapt it after the PR is merged.

---
*Created by `generate_demo.py`*